### PR TITLE
#50, #41, #49: fix missing MoviesFormat specifiers

### DIFF
--- a/VideoSort.py
+++ b/VideoSort.py
@@ -555,6 +555,21 @@ def path_subst(path, mapping):
     newpath = []
     plen = len(path)
     n = 0
+
+    # Sort list of mapping tuples by their first elements. First ascending by element,
+    # then descending by element length.
+    # Preparation to replace elements from longest to shortest in alphabetical order.
+    #
+    # >>> m = [('bb', 4), ('aa', 3), ('b', 6), ('aaa', 2), ('zzzz', 1), ('a', 5)]
+    # >>> m.sort(key=lambda t: t[0])
+    # >>> m
+    # [('a', 5), ('aa', 3), ('aaa', 2), ('b', 6), ('bb', 4), ('zzzz', 1)]
+    # >>> m.sort(key=lambda t: len(t[0]), reverse=True)
+    # >>> m
+    # [('zzzz', 1), ('aaa', 2), ('aa', 3), ('bb', 4), ('a', 5), ('b', 6)]
+    mapping.sort(key=lambda t: t[0])
+    mapping.sort(key=lambda t: len(t[0]), reverse=True)
+
     while n < plen:
         result = path[n]
         if result == '%':
@@ -843,13 +858,9 @@ def add_movies_mapping(guess, mapping):
     mapping.append(('%.t', title_two))
     mapping.append(('%_t', title_three))
 
-    mapping.append(('%sn', title))
-    mapping.append(('%s.n', title_two))
-    mapping.append(('%s_n', title_three))
-
-    mapping.append(('%sN', ttitle))
-    mapping.append(('%s.N', ttitle_two))
-    mapping.append(('%s_N', ttitle_three))
+    mapping.append(('%tT', ttitle))
+    mapping.append(('%t.T', ttitle_two))
+    mapping.append(('%t_T', ttitle_three))
 
     # year
     year = str(guess.get('year', ''))

--- a/testdata.json
+++ b/testdata.json
@@ -40,6 +40,12 @@
     "NZBPP_CATEGORY": "Kids cartoons"
   },
   {
+    "id": "movies-1",
+    "INPUTFILE": " The.Silence.Of.The.Lambs.1991.1080p.BluRay.CUSTOM.Plus.Criterion.Comm.DTS.x264-MaG.mkv",
+    "OUTPUTFILE": "/movies/The_Silence_of_the_Lambs 1991.mkv",
+    "NZBPO_MOVIESFORMAT": "%t_T %y.%ext"
+  },
+  {
     "id": "mini-1",
     "INPUTFILE": "Band.of.Brothers.E10.Points.720p.BRRip.mkv",
     "OUTPUTFILE": "/series/Mkv/Band of Brothers/Season 1/Band_of_Brothers - S01E10 - Points - 720p.BluRay.mkv",


### PR DESCRIPTION
Add missing MoviesFormat specifiers %tT, %t.T, %t_T.
Additionally sort specifiers in specific way before replacement to prevent short.
specifiers from early matching and thus preventing longer ones from working.
Add test case for %t_T - movie title (original letter case).